### PR TITLE
In-place directive manipulation support

### DIFF
--- a/spec/directives.spec.coffee
+++ b/spec/directives.spec.coffee
@@ -183,7 +183,7 @@ describe "Transparency", ->
           <li class="person" foobar="foo">daa</li>
         </ul>
       </div>')
-    debugger;
+
     doc.find('#persons').render(persons, directives)
 
     # Render twice to make sure the class names are not duplicated

--- a/spec/object_directives.spec.coffee
+++ b/spec/object_directives.spec.coffee
@@ -1,0 +1,162 @@
+if typeof module != 'undefined' && module.exports
+  require './spec_helper'
+  window.Transparency = require('../src/transparency')
+
+describe "Transparency", ->
+
+  it "should handle object-like directive with html() function", ->
+    doc = jQuery(
+     '<div>
+        <ul id="persons">
+          <li class="person"></li>
+        </ul>
+      </div>')
+
+    persons = [
+      person: "me"
+    ]
+
+    directives =
+      person:
+        html: ->
+          return "<span>Foobar</span>"
+
+    expected = jQuery(
+      '<div>
+        <ul id="persons">
+          <li class="person"><span>Foobar</span></li>
+        </ul>
+      </div>')
+
+    doc.find('#persons').render(persons, directives)
+
+    expect(doc.html()).htmlToBeEqual(expected.html())    
+
+  it "should handle object-like directive with text() function", ->
+    doc = jQuery(
+     '<div>
+        <ul id="persons">
+          <li class="person"></li>
+        </ul>
+      </div>')
+
+    persons = [
+      person: "me"
+    ]
+
+    directives =
+      person:
+        text: ->
+          return "Foobar >"
+
+    expected = jQuery(
+      '<div>
+        <ul id="persons">
+          <li class="person">Foobar &gt;</li>
+        </ul>
+      </div>')
+
+    doc.find('#persons').render(persons, directives)
+
+    # Render twice to make sure the class names are not duplicated
+    doc.find('#persons').render(persons, directives)
+    expect(doc.html()).htmlToBeEqual(expected.html())        
+
+  it "should handle object-like directives' attribute functions which manipulate input value", ->
+    doc = jQuery(
+     '<div>
+        <ul id="persons">
+          <li class="person"></li>
+        </ul>
+      </div>')
+
+    persons = [
+      person: "me"
+    ]
+
+    directives =
+      person:
+        class: (value) ->
+          return value + "-x"
+        text: ->
+          return "Mikko"
+
+    expected = jQuery(
+      '<div>
+        <ul id="persons">
+          <li class="person-x">Mikko</li>
+        </ul>
+      </div>')
+
+    doc.find('#persons').render(persons, directives)
+
+    expect(doc.html()).htmlToBeEqual(expected.html())    
+
+
+  # This case is not correctly handled as 
+  # we need to somehow make object directives understand lists better
+  xit "should handle complex object-like nested directives", ->
+    doc = jQuery(
+     '<div>
+        <ul id="persons">
+          <li class="person">
+              <p class="name"></p>
+              <a class="email"></a>
+          </li>
+        </ul>
+      </div>')
+
+    persons = [
+      person : [
+        { 
+          id : 9000
+          name : "Mikko"
+          email : "xmikko@opensourcehacker.com"
+        },
+        {
+          id : 9001
+          name : "Mikko 2"
+          email : "xmikko@opensourcehacker.com2"
+        }
+      ]
+    ]
+
+    directives =
+      person:
+
+        # XXX: Need to solve how to declare "id" function here
+        # Set id on the main element. Currently we do in-place manipulation
+        id: ->          
+          return this.id
+
+        # Recurse to a child element named "name"
+        name:
+          text: ->
+            return this.name
+
+        # Recurse to a child element named "email"
+        email:
+          text: ->
+            return this.email
+
+          href: (value) ->
+            return "mailto:" + this.email
+
+    expected = jQuery(
+      '<div>
+        <ul id="persons">
+          <li class="person" id="9000">
+              <p class="name">Mikko</p>
+              <a class="email" href="mailto:xmikko@opensourcehacker.com">xmikko@opensourcehacker.com</a>
+          </li>
+
+          <li class="person" id="9001" >
+              <p class="name">Mikko 2</p>
+              <a class="email" href="mailto:xmikko@opensourcehacker.com">xmikko@opensourcehacker.com2</a>
+          </li>          
+        </ul>
+      </div>')
+
+    doc.find('#persons').render(persons, directives)
+
+    expect(doc.html()).htmlToBeEqual(expected.html())          

--- a/src/transparency.coffee
+++ b/src/transparency.coffee
@@ -75,6 +75,15 @@ renderValues = (instance, model) ->
     setText(element, model) if element
 
 renderDirectives = (instance, model, directives, index) ->
+  renderFunctionDirectives instance, model, directives, index
+  renderObjectDirectives instance, model, directives, index
+
+renderFunctionDirectives = (instance, model, directives, index) ->
+  ###
+
+  Old-fashioned directive rendering loop.
+
+  ###
   for key, directiveFunction of directives when typeof directiveFunction == 'function'
 
     for element in matchingElements(instance, key)
@@ -90,11 +99,72 @@ renderDirectives = (instance, model, directives, index) ->
 
       setText element, directive.text
       setHtml element, directive.html
+
       for attr, value of directive when attr != 'html' and attr != 'text'
+
         # Save the original attribute value for the instance reuse
-        element.transparency.attributes       ||= {}
+
+        element.transparency.attributes ||= {}
         element.transparency.attributes[attr] ||= element.getAttribute attr
         element.setAttribute attr, value
+
+renderObjectDirectives = (instance, model, directives, index) ->
+  ###
+
+    Render directives which are objects.
+
+    Objects can contain as values
+
+      - text() function returning innerText() placement
+
+      - html() function returning innerHTML() placemenet
+
+      - Any attributes as text strings (properties...)
+
+      - Any other functions which will be get the attribute with the same
+        name as input and must output new value for this attribute as text string.
+        The signature is attr(sourceAttributeValue, dataIndex) and this points
+        to the data element  
+
+      - Objects, in which case this is considered as a nested directive
+
+    "New-fashioned" way to render directives. 
+  
+  ###
+
+  # Support object like directives, where value is declared as object
+  for key, directive of directives when typeof directive == 'object'
+
+    for element in matchingElements(instance, key)
+
+        # Handle element body value setting
+        if directive.text
+          setText element, directive.text.call(model, element, index)
+
+        if directive.html
+          value = directive.html.call(model, element, index)
+          if value
+            # html() is allowed to do in-place manipulation
+            setHtml element, value
+
+        for attr, value of directive when attr != "html" and attr != "text"
+
+          if typeof value == 'object'
+            # Nested directive, recurse into the matched object
+            renderObjectDirectives element, model, value, index
+            continue
+
+          # Do attribute function set/call
+          if typeof value == 'string'
+            # Input given as fixed string
+          else if typeof value == 'function'
+            srcValue = element.getAttribute attr
+            console.log "Calling function:" + attr
+            value = value.call(model, srcValue, index)
+          else
+            throw new Error "Unknown nested directive"
+
+          element.setAttribute attr, value
 
 renderChildren = (instance, model, directives) ->
   for key, value of model when typeof value == 'object'


### PR DESCRIPTION
Add support for cases where directive handler uses jQuery to directly manipulate DOM in-place, instead of returning text or HTML snippet. 

In complex manipulation cases this may be 
- Faster
- Cleaner
- Functionally difficult to achieve

The change itself is that if directive function returns null then don't try to run text or html replacement on this null value.
