### PR TITLE
Possible null value related bug

### DIFF
--- a/spec/directives.spec.coffee
+++ b/spec/directives.spec.coffee
@@ -248,3 +248,22 @@ describe "Transparency", ->
 
     expect(-> template.render data, directives)
     .toThrow new Error "Directive syntax is directive[element][attribute] = function(params)"
+
+  it "should use directive return value even if data value is null", ->
+    template = $ """
+      <div id="template">
+        <div class="name"></div>
+      </div>
+      """
+
+    expected = $ """
+      <div id="template">
+        <div class="name">Null value</div>
+      </div>
+      """
+
+    data       = name: null
+    directives = name: text: -> "Null value"
+
+    template.render data, directives
+    expect(template).toBeEqual expected


### PR DESCRIPTION
I would expect that regardless of the value in data the directive return
value should be used. If the data value is null and the directive
returns text content the return value of the directive is not applied to
the element.
