### PR TITLE
Update jsdom to 6.x for node 4.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "MIT"
   ],
   "dependencies": {
-    "jsdom": "^1.0.0"
+    "jsdom": "^6.5.0"
   },
   "devDependencies": {
     "bower": "^1.3.12",


### PR DESCRIPTION
This should be published as a new major version since this version of jsdom requires iojs 1+ or node 4+.

Fixes #142.